### PR TITLE
feat: sendDirect command + messagebox flag

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -17,6 +17,7 @@
                 "zh-cn": "首次出版"
             }
         },
+        "messagebox": true,
         "titleLang": {
             "en": "Hannah - Notification Manager",
             "de": "Hannah – Benachrichtigungsmanagerin",

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,8 +69,45 @@ class HannahNotificationmanager extends utils.Adapter {
         }
     }
 
+    /** @inheritdoc */
     public onMessage(obj: ioBroker.Message): void {
-        if (!obj || obj.command !== 'sendNotification') {
+        if (!obj) {
+            return;
+        }
+
+        if (obj.command === 'sendDirect') {
+            const { text, severity = 'notify' } = (obj.message ?? {}) as {
+                text?: string;
+                severity?: string;
+            };
+            if (!text) {
+                if (obj.callback) {
+                    this.sendTo(obj.from, obj.command, { sent: false, error: 'Kein Text' }, obj.callback);
+                }
+                return;
+            }
+            const payload = JSON.stringify({ type: 'direct', text, severity });
+            if (this.mqttClient?.connected) {
+                this.mqttClient.publish(this.config.hannah_topic, payload, { qos: 1 }, (err?: Error) => {
+                    if (obj.callback) {
+                        this.sendTo(
+                            obj.from,
+                            obj.command,
+                            err ? { sent: false, error: err.message } : { sent: true },
+                            obj.callback,
+                        );
+                    }
+                });
+            } else {
+                this.log.warn('MQTT nicht verbunden — Direct-Notification verworfen.');
+                if (obj.callback) {
+                    this.sendTo(obj.from, obj.command, { sent: false, error: 'MQTT nicht verbunden' }, obj.callback);
+                }
+            }
+            return;
+        }
+
+        if (obj.command !== 'sendNotification') {
             return;
         }
 


### PR DESCRIPTION
- io-package.json: messagebox: true — Adapter erscheint im Blockly sendTo-Dropdown
- main.ts: sendDirect-Command ergänzt — publiziert type:'direct' direkt an Hannah ohne Umweg über ioBroker-Notification-Pipeline